### PR TITLE
Fixup formatting includes and moves std includes down below Qt

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -67,25 +67,25 @@ IncludeBlocks: Regroup
 DerivePointerAlignment: false
 IncludeCategories:
   - Regex: '^<moc_.*>'
-    Priority: 2
-    SortPriority: 2
+    Priority: 1
+    SortPriority: 1
     CaseSensitive: false
   - Regex: '^<Q.*>'
-    Priority: 3
-    SortPriority: 3
+    Priority: 2
+    SortPriority: 2
     CaseSensitive: true
   - Regex: '^<.*/.*>'
     Priority: 4
     SortPriority: 4
   - Regex: '^<.*>'
-    Priority: 2
-    SortPriority: 2
-  - Regex: '^".*"'
     Priority: 5
     SortPriority: 5
+  - Regex: '^".*"'
+    Priority: 9
+    SortPriority: 9
   - Regex: '^".*/.*"'
-    Priority: 6
-    SortPriority: 6
+    Priority: 10
+    SortPriority: 10
 IndentAccessModifiers: false
 IndentCaseBlocks: true
 IndentCaseLabels: true

--- a/atlas/core/config.hpp
+++ b/atlas/core/config.hpp
@@ -5,11 +5,11 @@
 #ifndef ATLAS_CONFIG_HPP
 #define ATLAS_CONFIG_HPP
 
-#include <filesystem>
-
 #include <QObject>
 #include <QSettings>
 #include <QVariant>
+
+#include <filesystem>
 
 #include "ConfigNotification.hpp"
 #include "logging.hpp"

--- a/atlas/core/database/Binder.hpp
+++ b/atlas/core/database/Binder.hpp
@@ -5,11 +5,11 @@
 #ifndef ATLASGAMEMANAGER_BINDER_HPP
 #define ATLASGAMEMANAGER_BINDER_HPP
 
+#include <tracy/TracyC.h>
+
 #include <sqlite3.h>
 #include <string>
 #include <vector>
-
-#include <tracy/TracyC.h>
 
 #include "Database.hpp"
 #include "FunctionDecomp.hpp"

--- a/atlas/core/database/Database.hpp
+++ b/atlas/core/database/Database.hpp
@@ -5,10 +5,10 @@
 #ifndef ATLAS_DATABASE_HPP
 #define ATLAS_DATABASE_HPP
 
+#include <QObject>
+
 #include <filesystem>
 #include <sqlite3.h>
-
-#include <QObject>
 
 #include "core/logging.hpp"
 

--- a/atlas/core/database/Search.hpp
+++ b/atlas/core/database/Search.hpp
@@ -5,9 +5,9 @@
 #ifndef ATLAS_SEARCH_HPP
 #define ATLAS_SEARCH_HPP
 
-#include <vector>
-
 #include <QString>
+
+#include <vector>
 
 #include "core/database/record/Game.hpp"
 #include "core/search/QueryBuilder.hpp"

--- a/atlas/core/database/record/Game.hpp
+++ b/atlas/core/database/record/Game.hpp
@@ -5,10 +5,10 @@
 #ifndef ATLASGAMEMANAGER_GAME_HPP
 #define ATLASGAMEMANAGER_GAME_HPP
 
-#include <filesystem>
-
 #include <QFuture>
 #include <QPixmap>
+
+#include <filesystem>
 
 #include "core/Types.hpp"
 #include "core/config.hpp"

--- a/atlas/core/database/record/GameData.cpp
+++ b/atlas/core/database/record/GameData.cpp
@@ -4,9 +4,9 @@
 
 #include "GameData.hpp"
 
-#include <iostream>
-
 #include <QPixmapCache>
+
+#include <iostream>
 
 #include "Game.hpp"
 #include "Version.hpp"

--- a/atlas/core/database/record/Version.hpp
+++ b/atlas/core/database/record/Version.hpp
@@ -5,9 +5,9 @@
 #ifndef ATLAS_GAMEMETADATA_HPP
 #define ATLAS_GAMEMETADATA_HPP
 
-#include <filesystem>
-
 #include <QString>
+
+#include <filesystem>
 
 #include "core/Types.hpp"
 #include "core/database/Database.hpp"

--- a/atlas/core/database/record/tags.hpp
+++ b/atlas/core/database/record/tags.hpp
@@ -5,9 +5,9 @@
 #ifndef ATLASGAMEMANAGER_TAGS_HPP
 #define ATLASGAMEMANAGER_TAGS_HPP
 
-#include <cstdint>
-
 #include <QString>
+
+#include <cstdint>
 
 using TagID = std::uint64_t;
 [[maybe_unused]] constexpr TagID INVALID_TAG_ID { 0 };

--- a/atlas/core/database/remote/AtlasData.hpp
+++ b/atlas/core/database/remote/AtlasData.hpp
@@ -5,9 +5,9 @@
 #ifndef ATLASGAMEMANAGER_ATLASDATA_HPP
 #define ATLASGAMEMANAGER_ATLASDATA_HPP
 
-#include <memory>
-
 #include <QString>
+
+#include <memory>
 
 #include "core/Types.hpp"
 

--- a/atlas/core/database/remote/F95Data.hpp
+++ b/atlas/core/database/remote/F95Data.hpp
@@ -5,9 +5,9 @@
 #ifndef ATLASGAMEMANAGER_F95DATA_HPP
 #define ATLASGAMEMANAGER_F95DATA_HPP
 
-#include <memory>
-
 #include <QString>
+
+#include <memory>
 
 #include "core/Types.hpp"
 

--- a/atlas/core/gamelist/utils.hpp
+++ b/atlas/core/gamelist/utils.hpp
@@ -5,10 +5,10 @@
 #ifndef ATLASGAMEMANAGER_UTILS_HPP
 #define ATLASGAMEMANAGER_UTILS_HPP
 
+#include <QString>
+
 #include <filesystem>
 #include <vector>
-
-#include <QString>
 
 namespace gl
 {

--- a/atlas/core/imageManager.cpp
+++ b/atlas/core/imageManager.cpp
@@ -4,8 +4,6 @@
 
 #include "imageManager.hpp"
 
-#include <fstream>
-
 #include <QBuffer>
 #include <QCryptographicHash>
 #include <QFile>
@@ -16,6 +14,8 @@
 #include <QtConcurrentRun>
 
 #include <tracy/TracyC.h>
+
+#include <fstream>
 
 #include "config.hpp"
 #include "core/database/Transaction.hpp"

--- a/atlas/core/imageManager.hpp
+++ b/atlas/core/imageManager.hpp
@@ -5,11 +5,11 @@
 #ifndef ATLAS_IMAGEMANAGER_HPP
 #define ATLAS_IMAGEMANAGER_HPP
 
-#include <filesystem>
-
 #include <QFuture>
 #include <QPixmap>
 #include <QSize>
+
+#include <filesystem>
 
 #include "Types.hpp"
 

--- a/atlas/core/import/GameImportData.hpp
+++ b/atlas/core/import/GameImportData.hpp
@@ -5,9 +5,9 @@
 #ifndef ATLASGAMEMANAGER_GAMEIMPORTDATA_HPP
 #define ATLASGAMEMANAGER_GAMEIMPORTDATA_HPP
 
-#include <filesystem>
-
 #include <QString>
+
+#include <filesystem>
 
 #include "core/config.hpp"
 

--- a/atlas/core/import/GameScanner.cpp
+++ b/atlas/core/import/GameScanner.cpp
@@ -5,14 +5,15 @@
 #include "GameScanner.hpp"
 
 #include <moc_GameScanner.cpp>
-#include <queue>
-#include <ranges>
 
 #include <QFuture>
 #include <QtConcurrent>
 
 #include <tracy/Tracy.hpp>
 #include <tracy/TracyC.h>
+
+#include <queue>
+#include <ranges>
 
 #include "core/database/remote/AtlasData.hpp"
 #include "core/database/remote/F95Data.hpp"

--- a/atlas/core/import/Importer.hpp
+++ b/atlas/core/import/Importer.hpp
@@ -5,11 +5,11 @@
 #ifndef ATLASGAMEMANAGER_IMPORTER_HPP
 #define ATLASGAMEMANAGER_IMPORTER_HPP
 
-#include <filesystem>
-
 #include <QFuture>
 #include <QObject>
 #include <QPromise>
+
+#include <filesystem>
 
 #include "core/Types.hpp"
 #include "core/database/record/Game.hpp"

--- a/atlas/core/logging.hpp
+++ b/atlas/core/logging.hpp
@@ -5,9 +5,9 @@
 #ifndef ATLAS_LOGGING_HPP
 #define ATLAS_LOGGING_HPP
 
-#include <filesystem>
-
 #include <QString>
+
+#include <filesystem>
 
 #ifdef __GNUC__
 #pragma GCC diagnostic push

--- a/atlas/core/remote/AtlasRemote.cpp
+++ b/atlas/core/remote/AtlasRemote.cpp
@@ -4,7 +4,6 @@
 
 #include "AtlasRemote.hpp"
 
-#include <fstream>
 #include <moc_AtlasRemote.cpp>
 
 #include <QJsonArray>
@@ -12,6 +11,8 @@
 #include <QJsonObject>
 
 #include <tracy/TracyC.h>
+
+#include <fstream>
 
 #include "core/database/Transaction.hpp"
 #include "core/logging.hpp"

--- a/atlas/core/remote/extract.cpp
+++ b/atlas/core/remote/extract.cpp
@@ -2,11 +2,11 @@
 // Created by kj16609 on 6/14/23.
 //
 
+#include <tracy/Tracy.hpp>
+
 #include <filesystem>
 #include <fstream>
 #include <lz4frame.h>
-
-#include <tracy/Tracy.hpp>
 
 #include "core/logging.hpp"
 

--- a/atlas/core/remote/parsers/v0_parser.cpp
+++ b/atlas/core/remote/parsers/v0_parser.cpp
@@ -27,7 +27,7 @@ namespace remote::parsers::v0
 	}
 
 #define KEY_CHECK( key )                                                                                               \
-	if ( !obj.contains( key ) ) return false;
+  if ( !obj.contains( key ) ) return false;
 
 	bool validateAtlasKeys( const QJsonObject& obj )
 	{

--- a/atlas/core/utils/FileScanner.cpp
+++ b/atlas/core/utils/FileScanner.cpp
@@ -4,9 +4,9 @@
 
 #include "FileScanner.hpp"
 
-#include <queue>
-
 #include <tracy/Tracy.hpp>
+
+#include <queue>
 
 #include "core/logging.hpp"
 

--- a/atlas/core/utils/engineDetection/engineDetection.cpp
+++ b/atlas/core/utils/engineDetection/engineDetection.cpp
@@ -4,15 +4,15 @@
 
 #include "engineDetection.hpp"
 
-#include <algorithm>
-#include <array>
-#include <string>
-
 #include <QDir>
 #include <QDirIterator>
 #include <QMimeDatabase>
 
 #include <tracy/TracyC.h>
+
+#include <algorithm>
+#include <array>
+#include <string>
 
 #include "../../system.hpp"
 #include "core/logging.hpp"

--- a/atlas/core/utils/engineDetection/engineDetection.hpp
+++ b/atlas/core/utils/engineDetection/engineDetection.hpp
@@ -5,10 +5,10 @@
 #ifndef ATLAS_ENGINEDETECTION_HPP
 #define ATLAS_ENGINEDETECTION_HPP
 
+#include <QString>
+
 #include <filesystem>
 #include <vector>
-
-#include <QString>
 
 #include "core/utils/FileScanner.hpp"
 

--- a/atlas/core/utils/execute/executeProc.hpp
+++ b/atlas/core/utils/execute/executeProc.hpp
@@ -5,9 +5,9 @@
 #ifndef ATLAS_EXECUTEPROC_HPP
 #define ATLAS_EXECUTEPROC_HPP
 
-#include <string>
-
 #include <QFuture>
+
+#include <string>
 
 /**
  * @brief Executes the given path

--- a/atlas/main.cpp
+++ b/atlas/main.cpp
@@ -2,15 +2,15 @@
 // Created by kj16609 on 1/11/23.
 //
 
-#include <filesystem>
-#include <fstream>
-
 #include <QApplication>
 #include <QFile>
 #include <QImageReader>
 #include <QImageWriter>
 #include <QMessageBox>
 #include <QPixmapCache>
+
+#include <filesystem>
+#include <fstream>
 
 #include "core/config.hpp"
 #include "core/database/Database.hpp"

--- a/atlas/ui/delegates/ImageDelegate.cpp
+++ b/atlas/ui/delegates/ImageDelegate.cpp
@@ -4,12 +4,13 @@
 
 #include "ImageDelegate.hpp"
 
-#include <filesystem>
 #include <moc_ImageDelegate.cpp>
 
 #include <QPainter>
 
 #include <tracy/Tracy.hpp>
+
+#include <filesystem>
 
 #include "core/config.hpp"
 #include "ui/models/FilepathModel.hpp"

--- a/atlas/ui/importer/batchImporter/BatchImportModel.hpp
+++ b/atlas/ui/importer/batchImporter/BatchImportModel.hpp
@@ -5,9 +5,9 @@
 #ifndef ATLAS_BATCHIMPORTMODEL_HPP
 #define ATLAS_BATCHIMPORTMODEL_HPP
 
-#include <filesystem>
-
 #include <QAbstractTableModel>
+
+#include <filesystem>
 
 #include "core/import/GameImportData.hpp"
 

--- a/atlas/ui/importer/simpleImporter/SIModel.cpp
+++ b/atlas/ui/importer/simpleImporter/SIModel.cpp
@@ -5,10 +5,11 @@
 #include "SIModel.hpp"
 
 #include <moc_SIModel.cpp>
-#include <stack>
 
 #include <QColor>
 #include <QDir>
+
+#include <stack>
 
 std::uint64_t hash( const int first, const int second )
 {

--- a/atlas/ui/models/FilepathModel.hpp
+++ b/atlas/ui/models/FilepathModel.hpp
@@ -5,10 +5,10 @@
 #ifndef ATLASGAMEMANAGER_FILEPATHMODEL_HPP
 #define ATLASGAMEMANAGER_FILEPATHMODEL_HPP
 
+#include <QAbstractItemModel>
+
 #include <deque>
 #include <filesystem>
-
-#include <QAbstractItemModel>
 
 class FilepathModel final : public QAbstractListModel
 {

--- a/atlas/ui/models/RecordListModel.hpp
+++ b/atlas/ui/models/RecordListModel.hpp
@@ -5,10 +5,10 @@
 #ifndef ATLAS_RECORDLISTMODEL_HPP
 #define ATLAS_RECORDLISTMODEL_HPP
 
-#include <iostream>
-
 #include <QAbstractListModel>
 #include <QFutureWatcher>
+
+#include <iostream>
 
 #include "core/database/record/Game.hpp"
 

--- a/atlas/ui/notifications/NotificationSignalers.hpp
+++ b/atlas/ui/notifications/NotificationSignalers.hpp
@@ -21,10 +21,10 @@ namespace atlas::notifications
 
 	template < typename T >
 	concept has_get_signaler = requires( T t ) {
-		{
-			t.getSignaler()
-		} -> std::same_as< std::unique_ptr< typename T::Signaler > >;
-	};
+								   {
+									   t.getSignaler()
+								   } -> std::same_as< std::unique_ptr< typename T::Signaler > >;
+							   };
 
 	template < typename T >
 	concept has_valid_signaler = std::is_base_of_v< NotificationSignaler, typename T::Signaler >;


### PR DESCRIPTION
This mainly fixes the issue where the AutoMoc tool would eat shit in the event that filesystem was included before some Qt stuff. So this now moves around a bunch of includes to hopefully be in a better position