### PR TITLE
Binder fix

### DIFF
--- a/atlas/core/database/Binder.cpp
+++ b/atlas/core/database/Binder.cpp
@@ -14,7 +14,6 @@ Binder::Binder( const std::string_view sql )
 
 	if ( prepare_ret != SQLITE_OK )
 	{
-		atlas::logging::error( "Failed to prepare statement: \n\t{}", sql );
 		throw DatabaseException( format_ns::format(
 			"DB: Failed to prepare statement: \"{}\", Reason: \"{}\"", sql, sqlite3_errmsg( &Database::ref() ) ) );
 	}
@@ -26,6 +25,7 @@ Binder::~Binder() noexcept( false )
 {
 	if ( !ran ) [[unlikely]]
 	{
+		atlas::logging::debug( "Binder falloff. Running query" );
 		std::optional< std::tuple<> > tpl;
 		executeQuery( tpl );
 	}

--- a/atlas/core/database/Binder.cpp
+++ b/atlas/core/database/Binder.cpp
@@ -22,11 +22,12 @@ Binder::Binder( const std::string_view sql )
 	max_param_count = sqlite3_bind_parameter_count( stmt );
 }
 
-Binder::~Binder()
+Binder::~Binder() noexcept( false )
 {
 	if ( !ran ) [[unlikely]]
 	{
-		sqlite3_step( stmt );
+		std::optional< std::tuple<> > tpl;
+		executeQuery( tpl );
 	}
 
 	sqlite3_finalize( stmt );

--- a/atlas/core/database/Binder.hpp
+++ b/atlas/core/database/Binder.hpp
@@ -90,24 +90,25 @@ class Binder
 		requires( (!is_optional< T >) && (!is_tuple< T >))
 	void operator>>( T& t )
 	{
-		std::tuple< T > tpl;
+		std::optional< std::tuple< T > > tpl;
 
-		*this >> tpl;
+		executeQuery( tpl );
 
-		t = std::move( std::get< 0, T >( tpl ) );
+		if ( tpl.has_value() ) t = std::move( std::get< 0, T >( tpl.value() ) );
 	}
 
 	template < typename T >
 		requires( !is_optional< T > && (!is_tuple< T >))
 	void operator>>( std::optional< T >& t )
 	{
-		T tmp;
+		std::optional< std::tuple< T > > tpl;
 
-		*this >> tmp;
-		if constexpr ( std::is_move_assignable_v< T > )
-			t = std::move( tmp );
+		executeQuery( tpl );
+
+		if ( tpl.has_value() )
+			t = std::move( std::get< 0, T >( tpl.value() ) );
 		else
-			t = tmp;
+			t = std::nullopt;
 	}
 
 	template < typename Function >

--- a/atlas/core/database/Binder.hpp
+++ b/atlas/core/database/Binder.hpp
@@ -160,8 +160,6 @@ class Binder
 				std::string( sqlite3_sql( stmt ) ) ) );
 
 		ran = true;
-		using Tpl = std::tuple< Ts... >;
-		Tpl tpl;
 
 		if ( stmt == nullptr ) throw DatabaseException( "stmt was nullptr" );
 
@@ -176,6 +174,7 @@ class Binder
 				{
 					if constexpr ( sizeof...( Ts ) > 0 )
 					{
+						std::tuple< Ts... > tpl;
 						extractRow< 0, Ts... >( stmt, tpl );
 						tpl_opt = std::move( tpl );
 						return;

--- a/atlas/core/database/Binder.hpp
+++ b/atlas/core/database/Binder.hpp
@@ -103,18 +103,11 @@ class Binder
 	{
 		T tmp;
 
-		try
-		{
-			*this >> tmp;
-			if constexpr ( std::is_move_assignable_v< T > )
-				t = std::move( tmp );
-			else
-				t = tmp;
-		}
-		catch ( DatabaseException& e )
-		{
-			t = std::nullopt;
-		}
+		*this >> tmp;
+		if constexpr ( std::is_move_assignable_v< T > )
+			t = std::move( tmp );
+		else
+			t = tmp;
 	}
 
 	template < typename Function >
@@ -154,8 +147,7 @@ class Binder
 		{
 			tpl = std::move( opt_tpl.value() );
 		}
-		else
-			throw DatabaseException( "Expected 1 row. Got 0" );
+		return;
 	}
 
   private:

--- a/atlas/core/database/Binder.hpp
+++ b/atlas/core/database/Binder.hpp
@@ -152,7 +152,9 @@ class Binder
 	{
 		if ( param_counter != max_param_count )
 			throw AtlasException( format_ns::format(
-				"param_counter != max_param_count = {} != {} for query \"{}\"",
+				"Not enough parameters given for query! Given {}, Expected {}. param_counter != max_param_count = {} != {} for query \"{}\"",
+				param_counter,
+				max_param_count,
 				param_counter,
 				max_param_count,
 				std::string( sqlite3_sql( stmt ) ) ) );

--- a/atlas/core/database/FunctionDecomp.hpp
+++ b/atlas/core/database/FunctionDecomp.hpp
@@ -6,11 +6,12 @@
 #ifndef ATLASGAMEMANAGER_FUNCTIONDECOMP_HPP
 #define ATLASGAMEMANAGER_FUNCTIONDECOMP_HPP
 
+#include <concepts>
 #include <tuple>
 
 // Everything below here is just pure magic.
 // I'll try to decipher how the hell this works someday....
-template < typename >
+template < typename Function >
 struct FunctionDecomp;
 
 template < typename Function >
@@ -48,4 +49,6 @@ struct FunctionDecomp< ReturnType ( * )( Args... ) >
 template < typename Func >
 using FunctionReturn = FunctionDecomp< Func >::ResultType;
 
+template < typename Func >
+using FunctionTuple = FunctionDecomp< Func >::ArgTuple;
 #endif //ATLASGAMEMANAGER_FUNCTIONDECOMP_HPP

--- a/atlas/core/database/Transaction.cpp
+++ b/atlas/core/database/Transaction.cpp
@@ -46,8 +46,10 @@ namespace atlas::database
 	{
 		if ( !m_finished )
 		{
-			sqlite3_exec( &Database::ref(), "COMMIT TRANSACTION;", nullptr, nullptr, nullptr );
+			//sqlite3_exec( &Database::ref(), "COMMIT TRANSACTION;", nullptr, nullptr, nullptr );
+			*this << "COMMIT TRANSACTION";
 			m_finished = true;
+			atlas::logging::debug( "Commit called" );
 		}
 		else
 			throw TransactionInvalid( "Attempted to commit a finished transaction" );
@@ -58,8 +60,10 @@ namespace atlas::database
 	{
 		if ( !m_finished )
 		{
-			sqlite3_exec( &Database::ref(), "ABORT TRANSACTION;", nullptr, nullptr, nullptr );
+			*this << "ABORT TRANSACTION";
+			//sqlite3_exec( &Database::ref(), "ABORT TRANSACTION;", nullptr, nullptr, nullptr );
 			m_finished = true;
+			atlas::logging::debug( "Abort called" );
 		}
 		else
 			throw TransactionInvalid( "Attempted to abort a finished transaction" );

--- a/atlas/core/database/Transaction.cpp
+++ b/atlas/core/database/Transaction.cpp
@@ -34,7 +34,7 @@ namespace atlas::database
 	{
 		if ( !m_finished )
 		{
-			Binder( "ROLLBACK TRANSACTION" );
+			*this << "ROLLBACK TRANSACTION";
 			throw DatabaseException( "Allowed falloff via dtor in TransactionBase<true>!. Rolling back and failing." );
 		}
 
@@ -60,7 +60,7 @@ namespace atlas::database
 	{
 		if ( !m_finished )
 		{
-			*this << "ABORT TRANSACTION";
+			*this << "ROLLBACK TRANSACTION";
 			//sqlite3_exec( &Database::ref(), "ABORT TRANSACTION;", nullptr, nullptr, nullptr );
 			m_finished = true;
 			atlas::logging::debug( "Abort called" );

--- a/atlas/core/exceptions.hpp
+++ b/atlas/core/exceptions.hpp
@@ -69,6 +69,17 @@ namespace atlas::exceptions
 		{}
 	};
 
+	struct DatabaseRowMismatch : public DatabaseException
+	{
+		DatabaseRowMismatch( const char* const msg, const std::source_location loc = std::source_location::current() ) :
+		  DatabaseException( msg, loc )
+		{}
+
+		DatabaseRowMismatch( std::string msg, std::source_location loc = std::source_location::current() ) :
+		  DatabaseException( msg.c_str(), loc )
+		{}
+	};
+
 	struct ImportException : public AtlasException
 	{
 		ImportException( const char* const msg, const std::source_location loc = std::source_location::current() ) :

--- a/atlas/core/remote/parsers/v0_parser.cpp
+++ b/atlas/core/remote/parsers/v0_parser.cpp
@@ -217,11 +217,9 @@ namespace remote::parsers::v0
 
 	void insertF95Data( const QJsonObject& obj, Transaction& trans )
 	{
-		constexpr std::string_view query {
-			"INSERT INTO f95_zone_data (f95_id, atlas_id, banner_url, site_url, "
-			"last_thread_comment, thread_publish_date, last_record_update, views, "
-			"likes, tags, rating, screens, replies) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)"
-		};
+		constexpr std::string_view query { "INSERT INTO f95_zone_data (f95_id, atlas_id, banner_url, site_url, "
+			                               "last_thread_comment, thread_publish_date, last_record_update, views, "
+			                               "likes, rating, replies) VALUES (?,?,?,?,?,?,?,?,?,?,?)" };
 
 		trans << query << obj[ "f95_id" ].toInteger() << obj[ "atlas_id" ].toInteger() << obj[ "banner_url" ].toString()
 			  << obj[ "site_url" ].toString() << obj[ "last_thread_comment" ].toInteger()


### PR DESCRIPTION
Redo a lot of `Binder` code that makes it use a single executor function instead of having multiple implementations of it. Resulting in cases where one implementation might handle something wrong compared to the others.

Fixes issue where the f95_zone_data import from remote had a wrong parameter count. (Had 11. Expected 13)



