### PR TITLE
Bugfixing

### DIFF
--- a/atlas/core/database/record/game/Game.cpp
+++ b/atlas/core/database/record/game/Game.cpp
@@ -116,7 +116,7 @@ namespace atlas::records
 		if ( new_id == INVALID_ATLAS_ID )
 			throw RecordException( format_ns::format( "No Atlas data with this id: {}", atlas_id ).c_str() );
 
-		RapidTransaction() << "INSERT INTO atlas_mappings (atlas_id, game_id) VALUES (?,?)" << atlas_id << m_id;
+		RapidTransaction() << "INSERT INTO atlas_mappings (atlas_id, record_id) VALUES (?,?)" << atlas_id << m_id;
 
 		ptr->atlas_data = remote::AtlasRemoteData( atlas_id );
 	}

--- a/atlas/core/database/record/game/Game.cpp
+++ b/atlas/core/database/record/game/Game.cpp
@@ -128,7 +128,7 @@ namespace atlas::records
 			throw RecordException( format_ns::format( "Invalid F95 ID: {}", f95_id ).c_str() );
 
 		F95ID new_id { INVALID_ATLAS_ID };
-		RapidTransaction() << "SELECT new_id FROM f95_zone_data WHERE f95_id = ?" << f95_id >> new_id;
+		RapidTransaction() << "SELECT f95_id FROM f95_zone_data WHERE f95_id = ?" << f95_id >> new_id;
 
 		if ( new_id == INVALID_F95_ID )
 		{
@@ -136,7 +136,7 @@ namespace atlas::records
 			new_id = f95_id;
 		}
 
-		RapidTransaction() << "INSERT INTO f95_zone_mappings (game_id, f95_id) VALUES (?,?)" << m_id << new_id;
+		RapidTransaction() << "INSERT INTO f95_zone_mappings (record_id, f95_id) VALUES (?,?)" << m_id << new_id;
 
 		ptr->f95_data = remote::F95RemoteData( f95_id );
 	}

--- a/atlas/core/database/record/game/previews.cpp
+++ b/atlas/core/database/record/game/previews.cpp
@@ -59,8 +59,8 @@ namespace atlas::records
 				>> index;
 		}
 
-		RapidTransaction() << "INSERT INTO previews (record_id, path, position) VALUES (?,?,?)" << m_id << path
-						   << index;
+		RapidTransaction() << "INSERT INTO previews (record_id, path, position) VALUES (?,?,?) ON CONFLICT DO NOTHING"
+						   << m_id << path << index;
 		auto& previews { this->ptr->m_preview_paths };
 		previews.clear();
 

--- a/atlas/core/gamelist/parser.cpp
+++ b/atlas/core/gamelist/parser.cpp
@@ -26,6 +26,11 @@ namespace gl
 	GameListInfos parse( const std::filesystem::path& path )
 	try
 	{
+		if ( std::filesystem::is_directory( path ) )
+			throw AtlasException( format_ns::format( "Path given was a directory! {}", path ) );
+		if ( path.filename() != GL_INFO_FILENAME )
+			throw AtlasException( format_ns::format( "Path given was not a GL_Infos.ini file! {}", path ) );
+
 		GameListInfos infos;
 
 		const QSettings settings( QString::fromStdString( path.string() ), QSettings::IniFormat );

--- a/atlas/core/images/thumbnails.cpp
+++ b/atlas/core/images/thumbnails.cpp
@@ -32,6 +32,7 @@ namespace atlas::images
 		thumb = thumb.scaled( thumbnailSize(), Qt::KeepAspectRatio, Qt::SmoothTransformation );
 
 		const auto dest { thumbnailPath( image_path ) };
+		std::filesystem::create_directories( dest.parent_path() );
 		if ( !thumb.save( QString::fromStdString( dest.string() ), "webp", 95 ) )
 			throw AtlasException( format_ns::format( "Failed to save thumbnail for {} to {}", image_path, dest ) );
 
@@ -43,7 +44,7 @@ namespace atlas::images
 		if ( !std::filesystem::exists( image ) )
 			throw AtlasException(
 				format_ns::format( "attempted to get a thumbanil path for a non existant path: {}", image ) );
-		return image.parent_path() / ( image.stem().string() + ".thumb" );
+		return config::paths::images::getPath() / "thumbnails" / ( image.stem().string() + ".thumb" );
 	}
 
 	/**

--- a/atlas/core/import/GameImportData.hpp
+++ b/atlas/core/import/GameImportData.hpp
@@ -23,7 +23,9 @@ struct GameImportData
 	QString version;
 	std::size_t size;
 	std::uint64_t file_count;
+	//! Non relative path to possible executables
 	std::vector< std::filesystem::path > executables;
+	//! Non relative path to executable
 	std::filesystem::path executable;
 	std::array< QString, BannerType::SENTINEL > banners;
 	std::vector< QString > previews;

--- a/atlas/core/import/GameScanner.cpp
+++ b/atlas/core/import/GameScanner.cpp
@@ -42,20 +42,30 @@ void runner(
 	if ( promise.isCanceled() ) return;
 	if ( potential_executables.size() <= 0 ) throw NoExecutablesFound( folder );
 
+	auto gl_info { [ &folder ]() -> gl::GameListInfos
+		           {
+					   //Check if we have a GL_Infos.ini file
+					   if ( gl::dirHasGLInfo( folder ) )
+					   {
+						   atlas::logging::debug( "Found GL info for {}", folder );
+						   //We have one.
+						   return gl::parse( folder / GL_INFO_FILENAME );
+					   }
+					   else
+						   return {};
+				   }() };
+
 	auto [ title, creator, version, engine ] = [ & ]() -> regex::GroupsOutput
 	{
-		if ( gl::dirHasGLInfo( folder ) )
+		if ( gl_info.f95_thread_id == INVALID_F95_ID )
 		{
-			const auto gl_info { gl::parse( folder / GL_INFO_FILENAME ) };
-			// Grab information from remote.
-
-			if ( gl_info.f95_thread_id == INVALID_F95_ID )
-			{
-				//Unable to do anything with this
-				//TODO: Try the SHORT_ID from the atlas_id stuff to see if we can get a name match from the title.
-				return regex::extractGroups( regex, QString::fromStdString( folder.string() ) );
-			}
-
+			atlas::logging::warn( "Found GL info but it had an invalid F95 id!" );
+			//Unable to do anything with this
+			//TODO: Try the SHORT_ID from the atlas_id stuff to see if we can get a name match from the title.
+			return regex::extractGroups( regex, QString::fromStdString( folder.string() ) );
+		}
+		else
+		{
 			//Try to find the thread info
 			if ( !atlas::remote::hasF95DataFor( gl_info.f95_thread_id ) )
 			{
@@ -81,17 +91,6 @@ void runner(
 					return regex::extractGroups( regex, QString::fromStdString( folder.string() ) );
 				}
 			}
-		}
-		else
-		{
-			regex::GroupsOutput output { regex::extractGroups( regex, QString::fromStdString( folder.string() ) ) };
-
-			//std::optional< atlas::remote::AtlasRemoteData > atlas_data {atlas::records::Game().findAtlasData( output.title, output.creator )};
-			//atlas::remote::AtlasRemoteData atlas_data { atlas::records::Game().findAtlasData( output.title, output.creator ).value()->atlas_id};
-			//atlas::remote::F95RemoteData f95_data { atlas::records::Game().findF95Data(" ") };
-
-			//atlas::remote::AtlasRemoteData::
-			return output;
 		}
 	}();
 
@@ -155,16 +154,6 @@ void runner(
 			file_size += file.size;
 		}
 	}
-
-	auto gl_info { [ &folder ]() -> gl::GameListInfos
-		           {
-					   //Check if we have a GL_Infos.ini file
-					   if ( gl::dirHasGLInfo( folder ) )
-						   //We have one.
-						   return gl::parse( folder );
-					   else
-						   return {};
-				   }() };
 
 	// Fetch the game_id from the DB. Will return INVALID_RECORD_ID if not found
 	const auto game_id { atlas::records::fetchRecord( title, creator, engine ) };

--- a/atlas/core/import/GameScanner.cpp
+++ b/atlas/core/import/GameScanner.cpp
@@ -175,7 +175,7 @@ void runner(
 
 	if ( promise.isCanceled() ) return;
 	GameImportData data {
-		std::filesystem::relative( folder, base ),
+		std::move( folder ),
 		std::move( title ),
 		std::move( creator ),
 		std::move( engine ),

--- a/atlas/core/import/Importer.cpp
+++ b/atlas/core/import/Importer.cpp
@@ -50,7 +50,8 @@ namespace internal
 
 		promise.start();
 
-		const auto game_root { import_root / relative_path };
+		// If the import_root is empty then we should consider relative_path as the true path
+		const auto game_root { import_root.empty() ? relative_path : import_root / relative_path };
 		const auto executable_path { game_root / relative_executable };
 
 		TracyCZoneN( tracy_checkZone, "Check", true );

--- a/atlas/ui/delegates/ImageDelegate.cpp
+++ b/atlas/ui/delegates/ImageDelegate.cpp
@@ -25,6 +25,7 @@ void ImageDelegate::paint( QPainter* painter, const QStyleOptionViewItem& item, 
 		painter->fillRect( item.rect, item.palette.highlight() );
 	}
 
+	//If the pixmap is already loaded, draw it
 	if ( future.isFinished() )
 	{
 		const auto& pixmap { future.result() };
@@ -43,11 +44,15 @@ void ImageDelegate::paint( QPainter* painter, const QStyleOptionViewItem& item, 
 	{
 		m_model->refreshOnFuture( index, future );
 
-		const auto pixmap {
-			atlas::images::thumbnail( index.data( FilepathModel::FilepathRole ).value< std::filesystem::path >() )
-		};
+		if ( use_thumbnils )
+		{
+			// If the pixmap is not loaded, draw the thumbnail
+			const auto pixmap {
+				atlas::images::thumbnail( index.data( FilepathModel::FilepathRole ).value< std::filesystem::path >() )
+			};
 
-		painter->drawPixmap( item.rect.center() - pixmap.rect().center(), pixmap );
+			painter->drawPixmap( item.rect.center() - pixmap.rect().center(), pixmap );
+		}
 	}
 
 	painter->drawRect( item.rect );

--- a/atlas/ui/delegates/ImageDelegate.hpp
+++ b/atlas/ui/delegates/ImageDelegate.hpp
@@ -18,6 +18,8 @@ class ImageDelegate final : public QAbstractItemDelegate
 
   public:
 
+	bool use_thumbnils { true };
+
 	ImageDelegate( FilepathModel* model, QObject* parent = nullptr ) : QAbstractItemDelegate( parent ), m_model( model )
 	{}
 

--- a/atlas/ui/delegates/RecordBannerDelegate.cpp
+++ b/atlas/ui/delegates/RecordBannerDelegate.cpp
@@ -50,11 +50,6 @@ void RecordBannerDelegate::paint( QPainter* painter, const QStyleOptionViewItem&
 
 	if ( record.hasBanner( Normal ) )
 	{
-		if ( record.bannerPath( Normal ).extension() == ".gif" )
-		{
-			//NOT IMPLEMENTED
-		}
-
 		QFuture< QPixmap > banner { record.requestBanner( banner_size, aspect_ratio, Normal, USE_THUMBNAIL ) };
 
 		QPixmap pixmap;

--- a/atlas/ui/importer/singleImporter/SingleImporter.cpp
+++ b/atlas/ui/importer/singleImporter/SingleImporter.cpp
@@ -22,6 +22,7 @@
 SingleImporter::SingleImporter( QWidget* parent ) : QDialog( parent ), ui( new Ui::SingleImporter )
 {
 	ui->setupUi( this );
+	ui->previews->delegate()->use_thumbnils = false;
 }
 
 SingleImporter::~SingleImporter()

--- a/atlas/ui/importer/singleImporter/SingleImporter.cpp
+++ b/atlas/ui/importer/singleImporter/SingleImporter.cpp
@@ -11,6 +11,7 @@
 #include <QDir>
 #include <QFileDialog>
 #include <QMessageBox>
+#include <QMovie>
 
 #include "core/database/record/GameData.hpp"
 #include "core/gamelist/utils.hpp"
@@ -343,8 +344,20 @@ void SingleImporter::on_leBannerNormal_textChanged( const QString& text )
 		else
 		{
 			ui->leBannerNormal->setStyleSheet( "" );
-			ui->bannerNormal
-				->setPixmap( pixmap.scaled( ui->bannerTabWidget->size() - QSize( 50, 70 ), Qt::KeepAspectRatio ) );
+
+			if ( text.endsWith( ".gif" ) )
+			{
+				auto movie { std::make_unique< QMovie >( text ) };
+				movie->start();
+				ui->bannerNormal->setMovie( movie.get() );
+				m_movies.emplace_back( std::move( movie ) );
+			}
+			else
+			{
+				ui->bannerNormal->setMovie( nullptr );
+				ui->bannerNormal
+					->setPixmap( pixmap.scaled( ui->bannerTabWidget->size() - QSize( 50, 70 ), Qt::KeepAspectRatio ) );
+			}
 		}
 	}
 }
@@ -362,8 +375,20 @@ void SingleImporter::on_leBannerWide_textChanged( const QString& text )
 		else
 		{
 			ui->leBannerWide->setStyleSheet( "" );
-			ui->bannerWide
-				->setPixmap( pixmap.scaled( ui->bannerTabWidget->size() - QSize( 50, 70 ), Qt::KeepAspectRatio ) );
+
+			if ( text.endsWith( ".gif" ) )
+			{
+				auto movie { std::make_unique< QMovie >( text ) };
+				movie->start();
+				ui->bannerWide->setMovie( movie.get() );
+				m_movies.emplace_back( std::move( movie ) );
+			}
+			else
+			{
+				ui->bannerWide->setMovie( nullptr );
+				ui->bannerWide
+					->setPixmap( pixmap.scaled( ui->bannerTabWidget->size() - QSize( 50, 70 ), Qt::KeepAspectRatio ) );
+			}
 		}
 	}
 }
@@ -380,9 +405,21 @@ void SingleImporter::on_leBannerCover_textChanged( const QString& text )
 		}
 		else
 		{
-			ui->leBannerCover->setStyleSheet( "" );
-			ui->bannerCover
-				->setPixmap( pixmap.scaled( ui->bannerTabWidget->size() - QSize( 50, 70 ), Qt::KeepAspectRatio ) );
+			ui->leBannerLogo->setStyleSheet( "" );
+
+			if ( text.endsWith( ".gif" ) )
+			{
+				auto movie { std::make_unique< QMovie >( text ) };
+				movie->start();
+				ui->bannerCover->setMovie( movie.get() );
+				m_movies.emplace_back( std::move( movie ) );
+			}
+			else
+			{
+				ui->bannerCover->setMovie( nullptr );
+				ui->bannerCover
+					->setPixmap( pixmap.scaled( ui->bannerTabWidget->size() - QSize( 50, 70 ), Qt::KeepAspectRatio ) );
+			}
 		}
 	}
 }
@@ -400,8 +437,20 @@ void SingleImporter::on_leBannerLogo_textChanged( const QString& text )
 		else
 		{
 			ui->leBannerLogo->setStyleSheet( "" );
-			ui->bannerLogo
-				->setPixmap( pixmap.scaled( ui->bannerTabWidget->size() - QSize( 50, 70 ), Qt::KeepAspectRatio ) );
+
+			if ( text.endsWith( ".gif" ) )
+			{
+				auto movie { std::make_unique< QMovie >( text ) };
+				movie->start();
+				ui->bannerLogo->setMovie( movie.get() );
+				m_movies.emplace_back( std::move( movie ) );
+			}
+			else
+			{
+				ui->bannerLogo->setMovie( nullptr );
+				ui->bannerLogo
+					->setPixmap( pixmap.scaled( ui->bannerTabWidget->size() - QSize( 50, 70 ), Qt::KeepAspectRatio ) );
+			}
 		}
 	}
 }

--- a/atlas/ui/importer/singleImporter/SingleImporter.cpp
+++ b/atlas/ui/importer/singleImporter/SingleImporter.cpp
@@ -125,14 +125,14 @@ void SingleImporter::on_leRootPath_textChanged( [[maybe_unused]] const QString& 
 	{
 		ui->leExecutable->setEnabled( true );
 		ui->btnSelectExec->setEnabled( true );
-		ui->infoLabel->setText( "" );
+		ui->lblStatus->setText( "" );
 		fillIn();
 	}
 	else
 	{
 		ui->leExecutable->setEnabled( false );
 		ui->btnSelectExec->setEnabled( false );
-		ui->infoLabel->setText( "Root directory does not exist" );
+		ui->lblStatus->setText( "Root directory does not exist" );
 	}
 }
 
@@ -142,12 +142,12 @@ void SingleImporter::on_leExecutable_textChanged( [[maybe_unused]] const QString
 	if ( execFile.exists() )
 	{
 		ui->metadataFrame->setEnabled( true );
-		ui->infoLabel->setText( "" );
+		ui->lblStatus->setText( "" );
 	}
 	else
 	{
 		ui->btnNext->setEnabled( false );
-		ui->infoLabel->setText( "Executable does not exist. Should NOT be relative" );
+		ui->lblStatus->setText( "Executable does not exist. Should NOT be relative" );
 	}
 }
 
@@ -246,18 +246,18 @@ void SingleImporter::verifyDataEntry()
 
 	if ( title.isEmpty() || creator.isEmpty() || version.isEmpty() )
 	{
-		ui->infoLabel->setText( "One or more required fields are empty" );
+		ui->lblStatus->setText( "One or more required fields are empty" );
 		return;
 	}
 
 	if ( atlas::records::recordExists( title, creator, engine ) )
 	{
-		ui->infoLabel->setText( "Record already exists with the given title, creator, and engine" );
+		ui->lblStatus->setText( "Record already exists with the given title, creator, and engine" );
 		return;
 	}
 
 	ui->btnNext->setEnabled( true );
-	ui->infoLabel->setText( "" );
+	ui->lblStatus->setText( "" );
 }
 
 void SingleImporter::on_stackedWidget_currentChanged( int index )
@@ -474,6 +474,7 @@ void SingleImporter::fillIn()
 		ui->leVersion->setText( gl_data.version );
 
 		//TODO: Use the f95 id we get here to request more information from the f95_data table
+		ui->lblStatus->setText( "Found GL_Infos.ini. Took information from ini" );
 	}
 
 	//Check if there are banners

--- a/atlas/ui/importer/singleImporter/SingleImporter.hpp
+++ b/atlas/ui/importer/singleImporter/SingleImporter.hpp
@@ -21,6 +21,8 @@ class SingleImporter final : public QDialog
 	Q_OBJECT
 	Q_DISABLE_COPY_MOVE( SingleImporter )
 
+	std::vector< std::unique_ptr< QMovie > > m_movies;
+
   public:
 
 	explicit SingleImporter( QWidget* parent = nullptr );

--- a/atlas/ui/importer/singleImporter/SingleImporter.ui
+++ b/atlas/ui/importer/singleImporter/SingleImporter.ui
@@ -516,7 +516,7 @@
     </widget>
    </item>
    <item row="3" column="0">
-    <widget class="QLabel" name="infoLabel">
+    <widget class="QLabel" name="lblStatus">
      <property name="text">
       <string/>
      </property>

--- a/atlas/ui/importer/singleImporter/SingleImporter.ui
+++ b/atlas/ui/importer/singleImporter/SingleImporter.ui
@@ -11,26 +11,9 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>SingleImporter</string>
+   <string>Game Importer</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_3">
-   <item row="3" column="2">
-    <widget class="QPushButton" name="btnCancel">
-     <property name="text">
-      <string>Cancel</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="4">
-    <widget class="QPushButton" name="btnNext">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="text">
-      <string>Next</string>
-     </property>
-    </widget>
-   </item>
    <item row="2" column="0" colspan="6">
     <widget class="QStackedWidget" name="stackedWidget">
      <property name="currentIndex">
@@ -267,7 +250,7 @@
        <item row="4" column="0" colspan="6">
         <widget class="QTabWidget" name="bannerTabWidget">
          <property name="currentIndex">
-          <number>3</number>
+          <number>0</number>
          </property>
          <widget class="QWidget" name="normalTab">
           <attribute name="title">
@@ -505,6 +488,33 @@
      </widget>
     </widget>
    </item>
+   <item row="3" column="4">
+    <widget class="QPushButton" name="btnNext">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="text">
+      <string>Next</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="3">
+    <widget class="QPushButton" name="btnBack">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="text">
+      <string>Back</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="2">
+    <widget class="QPushButton" name="btnCancel">
+     <property name="text">
+      <string>Cancel</string>
+     </property>
+    </widget>
+   </item>
    <item row="3" column="0">
     <widget class="QLabel" name="infoLabel">
      <property name="text">
@@ -524,16 +534,6 @@
       </size>
      </property>
     </spacer>
-   </item>
-   <item row="3" column="3">
-    <widget class="QPushButton" name="btnBack">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="text">
-      <string>Back</string>
-     </property>
-    </widget>
    </item>
   </layout>
  </widget>

--- a/atlas/ui/mainwindow.cpp
+++ b/atlas/ui/mainwindow.cpp
@@ -321,6 +321,10 @@ void MainWindow::movePopup()
 	const auto point { ui->recordView->mapToGlobal( ui->recordView->rect().bottomRight() ) - QPoint { x, y } };
 
 	task_popup.move( point );
+
+	//Check if the popup is hidden since we call this once when we turn visible <=> invisible.
+	ui->btnLog->setText( task_popup.isVisible() ? "Hide Log" : "Show Log" );
+
 	//spdlog::info( "Max height of popup{}", ui->recordView->height() );
 	//task_popup.setMaximumHeight( ui->recordView->height() );
 }
@@ -360,7 +364,7 @@ void MainWindow::on_btnLog_pressed()
 {
 	auto& task_popup { atlas::notifications::handle() };
 	task_popup.setHidden( !task_popup.isHidden() );
-	ui->btnLog->setText( task_popup.isHidden() == true ? "Show Log" : "Hide Log" );
+	ui->btnLog->setText( task_popup.isHidden() ? "Show Log" : "Hide Log" );
 }
 
 void MainWindow::on_actionUpdates_triggered()

--- a/atlas/ui/mainwindow.cpp
+++ b/atlas/ui/mainwindow.cpp
@@ -115,10 +115,10 @@ MainWindow::MainWindow( QWidget* parent ) : QMainWindow( parent ), ui( new Ui::M
 	MainWindow::setWindowTitle( windowTitle );
 	
 	//Check for updates | Windows only
-	if(WIN32)
-	{
-		atlas::initUpdateHandler(false);
-	}
+	//	if(WIN32)
+	//	{
+	//		atlas::initUpdateHandler(false);
+	//	}
 
 	console->setModal( true );
 }

--- a/atlas/ui/mainwindow.cpp
+++ b/atlas/ui/mainwindow.cpp
@@ -11,7 +11,6 @@
 #include "core/version.hpp"
 #include "ui/dialog/AboutAtlas.hpp"
 #include "ui/dialog/SettingsDialog.hpp"
-
 #include "ui/dialog/StatsDialog.hpp"
 #include "ui/dialog/aboutqtdialog.h"
 #include "ui/importer/batchImporter/BatchImportDialog.hpp"
@@ -64,7 +63,7 @@ MainWindow::MainWindow( QWidget* parent ) : QMainWindow( parent ), ui( new Ui::M
 
 	atlas::notifications::initNotifications( this );
 	connect( &atlas::notifications::handle(), &NotificationManagerUI::requestMove, this, &MainWindow::movePopup );
-	ui->btnLog->setText("Hide Log");
+	ui->btnLog->setText( "Hide Log" );
 
 	//Share the recordView's model to gameList
 	//NEED TO OVERIDE THIS TO SET HEADER DATA
@@ -96,7 +95,6 @@ MainWindow::MainWindow( QWidget* parent ) : QMainWindow( parent ), ui( new Ui::M
 	ui->actionGameListImporter->setVisible( false );
 	ui->actionDownload->setVisible( false );
 
-
 	connect(
 		&atlas::import::internal::getNotifier(),
 		&atlas::import::ImportNotifier::notification,
@@ -113,12 +111,11 @@ MainWindow::MainWindow( QWidget* parent ) : QMainWindow( parent ), ui( new Ui::M
 
 	const QString windowTitle = QString::fromStdString( "ATLAS " ) + utils::version_string_qt();
 	MainWindow::setWindowTitle( windowTitle );
-	
+
 	//Check for updates | Windows only
-	//	if(WIN32)
-	//	{
-	//		atlas::initUpdateHandler(false);
-	//	}
+#ifdef _WIN32
+	atlas::initUpdateHandler( false );
+#endif
 
 	console->setModal( true );
 }
@@ -373,6 +370,5 @@ void MainWindow::on_actionUpdates_triggered()
 
 void MainWindow::on_actionConsoleWindow_triggered()
 {
-	
 	console->exec();
 }

--- a/atlas/ui/mainwindow.cpp
+++ b/atlas/ui/mainwindow.cpp
@@ -35,9 +35,9 @@ MainWindow::MainWindow( QWidget* parent ) : QMainWindow( parent ), ui( new Ui::M
 	connect( &record_search, &Search::searchCompleted, ui->recordView, &RecordListView::setRecords );
 
 	connect( ui->recordView, &RecordListView::openDetailedView, this, &MainWindow::switchToDetailed );
-	connect( ui->homeButton, &QToolButton::clicked, this, &MainWindow::on_homeButton_pressed );
-	connect( ui->btnAddGame, &QPushButton::clicked, this, &MainWindow::on_btnAddGame_pressed );
-	connect( ui->btnFilter, &QToolButton::clicked, this, &MainWindow::on_btnFilter_pressed );
+	//connect( ui->homeButton, &QToolButton::clicked, this, &MainWindow::on_homeButton_pressed );
+	//connect( ui->btnAddGame, &QPushButton::clicked, this, &MainWindow::on_btnAddGame_pressed );
+	//connect( ui->btnFilter, &QToolButton::clicked, this, &MainWindow::on_btnFilter_pressed );
 
 	//if ( config::geometry::main_window::hasValue() ) restoreGeometry( config::geometry::main_window::get() );
 	MainWindow::resize( QSize( config::grid_ui::windowWidth::get(), config::grid_ui::windowHeight::get() ) );
@@ -206,7 +206,7 @@ void MainWindow::on_homeButton_pressed()
 
 void MainWindow::on_btnAddGame_pressed()
 {
-	BatchImportDialog importer { this };
+	SingleImporter importer { this };
 	importer.exec();
 }
 

--- a/atlas/ui/notifications/NotificationManagerUI.cpp
+++ b/atlas/ui/notifications/NotificationManagerUI.cpp
@@ -63,7 +63,7 @@ void NotificationManagerUI::addNotification( Notification* notif )
 	//ui->scrollArea->resize(ui->scrollArea->width(), notificationWidgetHeight);
 	//ui->notifications->resize(ui->scrollArea->width(), notificationWidgetHeight);
 	ui->label->setText( QString( "%1 notifications" ).arg( ++active_notifications ) );
-	ui->btnHideNotifications->setVisible(true );
+	ui->btnHideNotifications->setVisible( true );
 	setHeight();
 }
 
@@ -71,27 +71,36 @@ void NotificationManagerUI::setHeight()
 {
 	int height { 0 };
 	int scroll_Area { 0 };
+	int clamp_max { 550 };
 	height += ui->NotificationFrame->height();
-	height += NotificationManagerUI::layout()->contentsMargins().bottom() + NotificationManagerUI::layout()->contentsMargins().top();
+	height += NotificationManagerUI::layout()->contentsMargins().bottom()
+	        + NotificationManagerUI::layout()->contentsMargins().top();
 
-	if ( ui->scrollArea->isVisible())
+	if ( ui->scrollArea->isVisible() )
 	{
 		//setFixedHeight( ui->NotificationFrame->height() );
-		if(ui->notifications->children().size() >1 )
+		if ( ui->notifications->children().size() > 1 )
 		{
 			for ( auto* notif : notifications() )
 			{
 				scroll_Area += notif->sizeHint().height() + ui->notifications->layout()->spacing();
+				if ( scroll_Area > clamp_max )
+				{
+					scroll_Area = clamp_max;
+					break;
+				}
 			}
-				scroll_Area += NotificationManagerUI::layout()->contentsMargins().bottom() + NotificationManagerUI::layout()->contentsMargins().top();
-			scroll_Area += 9; //This is to fix padding that was added in qss for horizontal bar. Do not remove. Will work with all other QSS
+			scroll_Area += NotificationManagerUI::layout()->contentsMargins().bottom()
+			             + NotificationManagerUI::layout()->contentsMargins().top();
+			//This is to fix padding that was added in qss for horizontal bar. Do not remove. Will work with all other QSS
+			scroll_Area += 9;
 		}
-		else{
+		else
+		{
 			height += 2;
 		}
-		
 	}
-	ui->scrollArea->setFixedHeight(scroll_Area );
+	ui->scrollArea->setFixedHeight( scroll_Area );
 	setFixedHeight( height + scroll_Area );
 	emit requestMove();
 }
@@ -132,7 +141,7 @@ void NotificationManagerUI::on_btnHideNotifications_pressed()
 			Notification* notif { dynamic_cast< Notification* >( child ) };
 			notif->setParent( nullptr );
 			notif->close();
-			notif->deleteLater();			
+			notif->deleteLater();
 		}
 	}
 

--- a/atlas/ui/notifications/NotificationManagerUI.cpp
+++ b/atlas/ui/notifications/NotificationManagerUI.cpp
@@ -63,7 +63,6 @@ void NotificationManagerUI::addNotification( Notification* notif )
 	//ui->scrollArea->resize(ui->scrollArea->width(), notificationWidgetHeight);
 	//ui->notifications->resize(ui->scrollArea->width(), notificationWidgetHeight);
 	ui->label->setText( QString( "%1 notifications" ).arg( ++active_notifications ) );
-	ui->btnHideNotifications->setVisible( true );
 	setHeight();
 }
 
@@ -128,7 +127,7 @@ void NotificationManagerUI::deleteNotification( Notification* ptr )
 }
 
 //Buttons
-void NotificationManagerUI::on_btnHideNotifications_pressed()
+void NotificationManagerUI::on_btnClearNotifications_pressed()
 {
 	// Close anything that ***CAN*** be closed.
 
@@ -139,15 +138,11 @@ void NotificationManagerUI::on_btnHideNotifications_pressed()
 		if ( child->objectName() == "MessageNotification" )
 		{
 			Notification* notif { dynamic_cast< Notification* >( child ) };
-			notif->setParent( nullptr );
-			notif->close();
-			notif->deleteLater();
+			deleteNotification( notif );
 		}
 	}
 
-	ui->label->setText( QString( "%1 notifications" ).arg( --active_notifications ) );
-	ui->scrollArea->setFixedHeight( 0 );
-	ui->btnHideNotifications->setVisible( false );
+	ui->label->setText( QString( "%1 notifications" ).arg( active_notifications ) );
 	setHeight();
 }
 

--- a/atlas/ui/notifications/NotificationManagerUI.hpp
+++ b/atlas/ui/notifications/NotificationManagerUI.hpp
@@ -47,7 +47,7 @@ class NotificationManagerUI final : public QDialog
 
   private slots:
 	void deleteNotification( Notification* ptr );
-	void on_btnHideNotifications_pressed();
+	void on_btnClearNotifications_pressed();
 	void on_btnMinimize_pressed();
 
   signals:

--- a/atlas/ui/notifications/NotificationManagerUI.ui
+++ b/atlas/ui/notifications/NotificationManagerUI.ui
@@ -156,7 +156,7 @@
        </spacer>
       </item>
       <item>
-       <widget class="QPushButton" name="btnHideNotifications">
+       <widget class="QPushButton" name="btnClearNotifications">
         <property name="sizePolicy">
          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
           <horstretch>0</horstretch>

--- a/atlas/ui/views/ImageView.cpp
+++ b/atlas/ui/views/ImageView.cpp
@@ -11,19 +11,16 @@
 
 void ImageView::setPaths( const std::vector< std::filesystem::path >& paths )
 {
-	auto model { dynamic_cast< FilepathModel* >( QListView::model() ) };
-	model->killLoaders();
-	model->setFilepaths( paths );
+	filepathModel()->killLoaders();
+	filepathModel()->setFilepaths( paths );
 }
 
 ImageView::ImageView( QWidget* parent ) : QListView( parent )
 {
-	auto* filepath_model { new FilepathModel() };
+	QListView::setModel( new FilepathModel() );
+	QListView::setItemDelegate( new ImageDelegate( filepathModel() ) );
 
-	QListView::setModel( filepath_model );
-	QListView::setItemDelegate( new ImageDelegate( filepath_model ) );
-
-	connect( static_cast< FilepathModel* >( model() ), &FilepathModel::reordered, this, &ImageView::modelReordered );
+	connect( filepathModel(), &FilepathModel::reordered, this, &ImageView::modelReordered );
 }
 
 void ImageView::modelReordered()
@@ -33,7 +30,7 @@ void ImageView::modelReordered()
 
 std::vector< std::filesystem::path > ImageView::selectedItems() const
 {
-	auto model { dynamic_cast< FilepathModel* >( QListView::model() ) };
+	auto model { filepathModel() };
 
 	std::vector< std::filesystem::path > paths;
 
@@ -48,7 +45,7 @@ std::vector< std::filesystem::path > ImageView::selectedItems() const
 
 std::vector< std::filesystem::path > ImageView::paths() const
 {
-	return static_cast< FilepathModel* >( model() )->getFilepaths();
+	filepathModel()->getFilepaths();
 }
 
 std::vector< QString > ImageView::pathsQString() const

--- a/atlas/ui/views/ImageView.hpp
+++ b/atlas/ui/views/ImageView.hpp
@@ -9,9 +9,8 @@
 #include <QMouseEvent>
 
 #include "core/database/record/GameData.hpp"
-
-class FilepathModel;
-class ImageDelegate;
+#include "ui/delegates/ImageDelegate.hpp"
+#include "ui/models/FilepathModel.hpp"
 
 class ImageView final : public QListView
 {
@@ -24,6 +23,10 @@ class ImageView final : public QListView
 	std::vector< std::filesystem::path > selectedItems() const;
 	std::vector< std::filesystem::path > paths() const;
 	std::vector< QString > pathsQString() const;
+
+	FilepathModel* filepathModel() const { return dynamic_cast< FilepathModel* >( QListView::model() ); }
+
+	ImageDelegate* delegate() const { return dynamic_cast< ImageDelegate* >( QListView::itemDelegate() ); }
 
   private slots:
 	void modelReordered();


### PR DESCRIPTION
- Fixes issue where importing images could sometimes conflict and throw an error when it should fail silently since it doesn't matter
- Fixes notification menu leaving to orbit once reaching a super large size
- Fixes hiding initUpdateHandler on linux
- Fixes closing all notifications menu & fixes button text being incorrect sometimes
- Fixes GL parser not actually being used during import process
- Add back single importer and attach to 'add game' main menu button
- Adds gif support for single importer when viewing banners that are animated