### PR TITLE
Scanner list select

### DIFF
--- a/atlas/core/utils/ImageCache/ImageCache.hpp
+++ b/atlas/core/utils/ImageCache/ImageCache.hpp
@@ -8,6 +8,7 @@
 #include <QPixmap>
 
 #include <chrono>
+#include <map>
 #include <mutex>
 
 namespace atlas::cache

--- a/atlas/ui/importer/batchImporter/BatchImportDialog.hpp
+++ b/atlas/ui/importer/batchImporter/BatchImportDialog.hpp
@@ -50,6 +50,7 @@ class BatchImportDialog final : public QDialog
 	void finishedPreProcessing();
 	void importFailure( const QString top, const QString bottom );
 	void waitingOnThreads();
+	void keyPressEvent( QKeyEvent* event ) override;
 
   signals:
 	void addToModel( const GameImportData data );

--- a/atlas/ui/importer/batchImporter/BatchImportModel.cpp
+++ b/atlas/ui/importer/batchImporter/BatchImportModel.cpp
@@ -436,3 +436,13 @@ bool BatchImportModel::isGood() const
 
 	return true;
 }
+
+bool BatchImportModel::removeRows( int row, int count, const QModelIndex& parent )
+{
+	if ( row < 0 || row >= rowCount() || count < 0 || ( row + count ) > rowCount() ) return false;
+
+	beginRemoveRows( parent, row, row + count - 1 );
+	m_data.erase( m_data.begin() + row, m_data.begin() + row + count );
+	endRemoveRows();
+	return true;
+}

--- a/atlas/ui/importer/batchImporter/BatchImportModel.hpp
+++ b/atlas/ui/importer/batchImporter/BatchImportModel.hpp
@@ -46,6 +46,8 @@ class BatchImportModel final : public QAbstractTableModel
 	bool setData( const QModelIndex& index, const QVariant& value, int role = Qt::EditRole ) override;
 	void sort( int idx, Qt::SortOrder order = Qt::AscendingOrder ) override;
 
+	bool removeRows( int row, int count, const QModelIndex& parent = {} ) override;
+
 	void clearData();
 
 	//! Returns true if we are okay to import.


### PR DESCRIPTION
Fixes the inability to select rows. Makes it so that double click is required to edit and now it is possible to delete rows.

Fixes #131 