### PR TITLE
Fixes issue with linux not being able to properly load the 7z module

### DIFF
--- a/atlas/core/utils/extraction/extractor.cpp
+++ b/atlas/core/utils/extraction/extractor.cpp
@@ -22,7 +22,7 @@ namespace atlas::utils
 		{ // bit7z classes can throw BitException objects
 			using namespace bit7z;
 
-			Bit7zLibrary lib { "7z.dll" };
+			Bit7zLibrary lib {};
 			BitFileExtractor extractor { lib, BitFormat::Auto };
 			uint64_t data_size {};
 

--- a/atlas/core/utils/extraction/extractor.cpp
+++ b/atlas/core/utils/extraction/extractor.cpp
@@ -4,6 +4,8 @@
 
 #include "extractor.hpp"
 
+#include <moc_extractor.cpp>
+
 #include <bit7z/bitarchivereader.hpp>
 #include <bit7z/bitfileextractor.hpp>
 

--- a/atlas/core/utils/extraction/extractor.hpp
+++ b/atlas/core/utils/extraction/extractor.hpp
@@ -6,8 +6,6 @@
 #ifndef ATLAS_EXTRACTOR_HPP
 #define ATLAS_EXTRACTOR_HPP
 
-#include <filesystem>
-
 #include "core/import/GameImportData.hpp"
 #include "ui/notifications/ProgressNotification.hpp"
 

--- a/atlas/ui/importer/extractionImporter/ExtractionImportDialog.cpp
+++ b/atlas/ui/importer/extractionImporter/ExtractionImportDialog.cpp
@@ -469,8 +469,10 @@ QStringList ExtractionImportDialog::findExecutables( const std::string file )
 		using namespace bit7z;
 
 		//load dll from folder root
-		Bit7zLibrary lib { "7z.dll" };
+		Bit7zLibrary lib {};
 		BitArchiveReader arc { lib, file, BitFormat::Auto };
+
+		arc.test();
 
 		for ( const auto& item : arc )
 		{

--- a/cmake_modules/dependencies/bit7z.cmake
+++ b/cmake_modules/dependencies/bit7z.cmake
@@ -1,3 +1,29 @@
 option(BIT7Z_AUTO_FORMAT "Enable extraction for all formats" ON)
 
+if (UNIX)
+	# This is to fix a problem with linux having ancient 7z versions
+
+	#Check what version of 7z the system has
+	execute_process(COMMAND 7z OUTPUT_VARIABLE _7Z_VERSION)
+	#Check if the command executed properly
+	if (NOT _7Z_VERSION)
+		message(FATAL_ERROR "7z not found. Please install p7zip")
+	endif ()
+
+	string(REGEX MATCH "([0-9]+)\\.([0-9]+)" _7Z_VERSION "${_7Z_VERSION}")
+	string(REGEX MATCH "([0-9]+)" _7Z_VERSION_MAJOR "${_7Z_VERSION}")
+	string(REGEX MATCH "([0-9]+)$" _7Z_VERSION_MINOR "${_7Z_VERSION}")
+
+	message("-- System 7z version: ${_7Z_VERSION_MAJOR}.${_7Z_VERSION_MINOR}")
+
+	# Is it before 23.01?
+	if (_7Z_VERSION_MAJOR LESS 23 OR (_7Z_VERSION_MAJOR EQUAL 23 AND _7Z_VERSION_MINOR LESS 1))
+		# Yes. We need to do the fix
+		option(BIT7Z_USE_LEGACY_IUNKNOWN "Use legacy IUNKNOWN" ON)
+	else ()
+		# No. We don't need to do the fix
+		option(BIT7Z_USE_LEGACY_IUNKNOWN "Use legacy IUNKNOWN" OFF)
+	endif ()
+endif ()
+
 add_subdirectory(${CMAKE_SOURCE_DIR}/dependencies/bit7z) # Path to the 11zip

--- a/cmake_modules/dependencies/bit7z.cmake
+++ b/cmake_modules/dependencies/bit7z.cmake
@@ -24,6 +24,8 @@ if (UNIX)
 		# No. We don't need to do the fix
 		option(BIT7Z_USE_LEGACY_IUNKNOWN "Use legacy IUNKNOWN" OFF)
 	endif ()
+
+	option(BIT7Z_AUTO_FORMAT ON)
 endif ()
 
 add_subdirectory(${CMAKE_SOURCE_DIR}/dependencies/bit7z) # Path to the 11zip


### PR DESCRIPTION
According to rikyoz/bit7z there is a major version change at 23.01 that completely breaks backwards compatability. In order to get linux distros happy with this we'll have to turn on the flag `BIT7Z_USE_LEGACY_IUNKNOWN` when we encounter a 7z shared library with a lower version then 23.01. 

> On Linux and macOS, 7-zip v23.01 introduced breaking changes to the IUnknown interface. If you build bit7z for such a version of 7-zip (the default), it will not support using the shared libraries from previous versions of 7-zip (or from p7zip). Conversely, bit7z made for earlier versions of 7-zip or for p7zip is incompatible with the shared libraries from 7-zip v23.01 and later.

> You can build the shared libraries of 7-zip v23.01 in a backward-compatible mode by defining the macro Z7_USE_VIRTUAL_DESTRUCTOR_IN_IUNKNOWN. If this is your case, you can build bit7z for v23.01 using the option BIT7Z_USE_LEGACY_IUNKNOWN (in this case, bit7z will be compatible also with previous versions of 7-zip/p7zip).